### PR TITLE
k6のデータをdatadogに流せるように設定を追加

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,3 @@
+# Datadogの設定
+DD_API_KEY=<DD_API_KEY>
+DD_SITE=<DD_SITE>

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 k6-operator
+.env

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ k6 run simple-k6-sample.js --rps 100 --out influxdb=http://localhost:8086/loadte
 
 ※ grafana側の設定は[ブログ](https://it-blue-collar-dairy.com/try-to-use-k6/)に記載しています。
 
+#### 結果をDatadogで表示する
+
+`.env.template`を`.env`にリネームし、DD_API_KEYとDD_SITEを設定
+
+```shell
+K6_STATSD_ENABLE_TAGS=true k6 run simple-k6-sample.js --rps 100 --out statsd
+```
+
 ## k3d上でk6-operatorの実行
 
 [k6-operator](https://github.com/grafana/k6-operator)はkubernetes上でk6の分散実行を行うプロジェクト

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,3 +22,19 @@ services:
       - '8086:8086'
     environment:
       - INFLUXDB_DB=loadtest
+
+  datadog-agent:
+    image: datadog/agent:latest
+    container_name: datadog-agent
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+    environment:
+      - DD_API_KEY=${DD_API_KEY}
+      - DD_SITE=${DD_SITE}
+      - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=1
+    env_file:
+      - .env
+    ports:
+      - "8125:8125/udp"


### PR DESCRIPTION
# 概要

k6のデータをdatadogに流せるように設定を追加

## やったこと

- datadog-agentをdocker-composeで起動するように修正
- envファイルのテンプレートと手順を追加